### PR TITLE
Fix cURL error

### DIFF
--- a/core/class/ecowatt.class.php
+++ b/core/class/ecowatt.class.php
@@ -42,6 +42,7 @@ class ecowatt extends eqLogic {
 
 	public static function valueFromUrl($_url) {
 		$request_http = new com_http($_url);
+        $request_http->setUserAgent('curl');
 		$dataUrl = $request_http->exec();
 		if (!is_json($dataUrl)) {
 			return;


### PR DESCRIPTION
EDF API seems to not accept get request when UserAgent is empty.
Setting UserAgent to a dummy value fixes the problem.

De mon côté j'avais l'erreur suivante: "Erreur sur la fonction cronHourly du plugin : Echec de la requête HTTP : https://particulier.edf.fr/bin/edf_rc/servlets/ejptemponew?Date_a_remonter=2019-05-09&TypeAlerte=TEMPO cURL error : Operation timed out after 2001 milliseconds with 0 bytes received"

D'autres personnes sur le forum semblent aussi rencontrer le même problème: https://www.jeedom.com/forum/viewtopic.php?f=149&t=10543&start=120

Il semble que le problème vienne du fait que le serveur d'API d'EDF n'accepte plus les requêtes si le UserAgent est vide.
